### PR TITLE
Fix decoding triplet into MSB and LSB (byte)

### DIFF
--- a/src/core/Utils.mjs
+++ b/src/core/Utils.mjs
@@ -1206,6 +1206,30 @@ class Utils {
         }[token];
     }
 
+    /**
+     * Iterate object in chunks of given size.
+     *
+     * @param {Iterable} iterable
+     * @param {number} chunksize
+     */
+    static* chunked(iterable, chunksize) {
+        const iterator = iterable[Symbol.iterator]();
+        while (true) {
+            const res = [];
+            for (let i = 0; i < chunksize; i++) {
+                const next = iterator.next();
+                if (next.done) {
+                    break;
+                }
+                res.push(next.value);
+            }
+            if (res.length) {
+                yield res;
+            } else {
+                return;
+            }
+        }
+    }
 }
 
 /**

--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -20,6 +20,8 @@
             "From Octal",
             "To Base32",
             "From Base32",
+            "To Base45",
+            "From Base45",
             "To Base58",
             "From Base58",
             "To Base62",

--- a/src/core/lib/Base45.mjs
+++ b/src/core/lib/Base45.mjs
@@ -26,4 +26,4 @@ export function highlightFromBase45(pos, args) {
     return pos;
 }
 
-export const ALPHABET = Utils.expandAlphRange("0-9A-Z $%*+-./:").join("");
+export const ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:";

--- a/src/core/lib/Base45.mjs
+++ b/src/core/lib/Base45.mjs
@@ -6,8 +6,6 @@
  * @license Apache-2.0
  */
 
-import Utils from "../Utils.mjs";
-
 /**
  * Highlight to Base45
  */

--- a/src/core/lib/Base45.mjs
+++ b/src/core/lib/Base45.mjs
@@ -1,0 +1,29 @@
+/**
+ * Base45 resources.
+ *
+ * @author Thomas Weißschuh [thomas@t-8ch.de]
+ * @copyright Crown Copyright 2021
+ * @license Apache-2.0
+ */
+
+import Utils from "../Utils.mjs";
+
+/**
+ * Highlight to Base45
+ */
+export function highlightToBase45(pos, args) {
+    pos[0].start = Math.floor(pos[0].start / 2) * 3;
+    pos[0].end = Math.ceil(pos[0].end / 2) * 3;
+    return pos;
+}
+
+/**
+ * Highlight from Base45
+ */
+export function highlightFromBase45(pos, args) {
+    pos[0].start = Math.floor(pos[0].start / 3) * 2;
+    pos[0].end = Math.ceil(pos[0].end / 3) * 2;
+    return pos;
+}
+
+export const ALPHABET = Utils.expandAlphRange("0-9A-Z $%*+-./:").join("");

--- a/src/core/operations/FromBase45.mjs
+++ b/src/core/operations/FromBase45.mjs
@@ -58,8 +58,19 @@ class FromBase45 extends Operation {
                 throw new OperationError(`Triplet too large: '${triple.join("")}'`);
             }
 
-            res.push(b>>8);
+            if (triple.length > 2) {
+                /**
+                 * The last triple may only have 2 bytes so we push the MSB when we got 3 bytes
+                 * Pushing MSB
+                 */
+                res.push(b>>8);
+            }
+
+            /**
+             * Pushing LSB
+             */
             res.push(b&0xff);
+
         }
 
         return res;

--- a/src/core/operations/FromBase45.mjs
+++ b/src/core/operations/FromBase45.mjs
@@ -1,0 +1,71 @@
+/**
+ * @author Thomas Weißschuh [thomas@t-8ch.de]
+ * @copyright Crown Copyright 2021
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
+import Utils from "../Utils.mjs";
+
+
+/**
+ * From Base45 operation
+ */
+class FromBase45 extends Operation {
+
+    /**
+     * FromBase45 constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "From Base45";
+        this.module = "Default";
+        this.description = "Base45 is a notation for encoding arbitrary byte data using a restricted set of symbols that can be conveniently used by humans and processed by computers. The high number base results in shorter strings than with the decimal or hexadecimal system. Base45 is optimized for usage with QR codes.";
+        this.infoURL = "https://wikipedia.org/wiki/List_of_numeral_systems";
+        this.inputType = "string";
+        this.outputType = "byteArray";
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {byteArray}
+     */
+    run(input, args) {
+        const alphabet = Utils.expandAlphRange("0-9A-Z $%*+-./:").join("");
+        if (!input) return [];
+
+        const res = [];
+
+        for (const triple of Utils.chunked(input, 3)) {
+            triple.reverse();
+            let b = 0;
+            for (const c of triple) {
+                const idx = alphabet.indexOf(c);
+                if (idx === -1) {
+                    throw new OperationError(`Character not in alphabet: '${c}'`);
+                }
+                b *= 45;
+                b += idx;
+            }
+
+            if (b > 65535) {
+                throw new OperationError(`Triplet too large: '${triple.join("")}'`);
+            }
+
+            if (Math.floor(b / 256)) {
+                res.push(Math.floor(b / 256));
+            }
+            if (b % 256) {
+                res.push(b % 256);
+            }
+        }
+
+        return res;
+    }
+
+}
+
+export default FromBase45;

--- a/src/core/operations/FromBase45.mjs
+++ b/src/core/operations/FromBase45.mjs
@@ -58,12 +58,8 @@ class FromBase45 extends Operation {
                 throw new OperationError(`Triplet too large: '${triple.join("")}'`);
             }
 
-            if (Math.floor(b / 256)) {
-                res.push(Math.floor(b / 256));
-            }
-            if (b % 256) {
-                res.push(b % 256);
-            }
+            res.push(b>>8);
+            res.push(b&0xff);
         }
 
         return res;

--- a/src/core/operations/FromBase45.mjs
+++ b/src/core/operations/FromBase45.mjs
@@ -4,6 +4,7 @@
  * @license Apache-2.0
  */
 
+import {ALPHABET, highlightToBase45, highlightFromBase45} from "../lib/Base45.mjs";
 import Operation from "../Operation.mjs";
 import OperationError from "../errors/OperationError.mjs";
 import Utils from "../Utils.mjs";
@@ -26,6 +27,9 @@ class FromBase45 extends Operation {
         this.infoURL = "https://wikipedia.org/wiki/List_of_numeral_systems";
         this.inputType = "string";
         this.outputType = "byteArray";
+
+        this.highlight = highlightFromBase45;
+        this.highlightReverse = highlightToBase45;
     }
 
     /**
@@ -34,7 +38,6 @@ class FromBase45 extends Operation {
      * @returns {byteArray}
      */
     run(input, args) {
-        const alphabet = Utils.expandAlphRange("0-9A-Z $%*+-./:").join("");
         if (!input) return [];
 
         const res = [];
@@ -43,7 +46,7 @@ class FromBase45 extends Operation {
             triple.reverse();
             let b = 0;
             for (const c of triple) {
-                const idx = alphabet.indexOf(c);
+                const idx = ALPHABET.indexOf(c);
                 if (idx === -1) {
                     throw new OperationError(`Character not in alphabet: '${c}'`);
                 }

--- a/src/core/operations/ToBase45.mjs
+++ b/src/core/operations/ToBase45.mjs
@@ -1,0 +1,74 @@
+/**
+ * @author Thomas Weißschuh [thomas@t-8ch.de]
+ * @copyright Crown Copyright 2021
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation.mjs";
+import Utils from "../Utils.mjs";
+
+/**
+ * To Base45 operation
+ */
+class ToBase45 extends Operation {
+
+    /**
+     * ToBase45 constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "To Base45";
+        this.module = "Default";
+        this.description = "Base45 is a notation for encoding arbitrary byte data using a restricted set of symbols that can be conveniently used by humans and processed by computers. The high number base results in shorter strings than with the decimal or hexadecimal system. Base45 is optimized for usage with QR codes.";
+        this.infoURL = "https://wikipedia.org/wiki/List_of_numeral_systems";
+        this.inputType = "ArrayBuffer";
+        this.outputType = "string";
+        this.args = [
+            {
+                name: "Alphabet",
+                type: "string",
+                value: "0-9A-Za-z"
+            }
+        ];
+    }
+
+    /**
+     * @param {ArrayBuffer} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    run(input, args) {
+        const alphabet = Utils.expandAlphRange("0-9A-Z $%*+-./:").join("");
+        input = new Uint8Array(input);
+        if (!input) return "";
+
+        const res = [];
+
+        for (const pair of Utils.chunked(input, 2)) {
+            let b = 0;
+            for (const e of pair) {
+                b *= 256;
+                b += e;
+            }
+
+            let chars = 0;
+            do {
+                res.push(alphabet[b % 45]);
+                chars++;
+                b = Math.floor(b / 45);
+            } while (b > 0);
+
+            if (chars < 2) {
+                res.push("0");
+            }
+        }
+
+
+        return res.join("");
+
+    }
+
+}
+
+export default ToBase45;

--- a/src/core/operations/ToBase45.mjs
+++ b/src/core/operations/ToBase45.mjs
@@ -4,6 +4,7 @@
  * @license Apache-2.0
  */
 
+import {ALPHABET, highlightToBase45, highlightFromBase45} from "../lib/Base45.mjs";
 import Operation from "../Operation.mjs";
 import Utils from "../Utils.mjs";
 
@@ -31,6 +32,9 @@ class ToBase45 extends Operation {
                 value: "0-9A-Za-z"
             }
         ];
+
+        this.highlight = highlightToBase45;
+        this.highlightReverse = highlightFromBase45;
     }
 
     /**
@@ -39,7 +43,6 @@ class ToBase45 extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        const alphabet = Utils.expandAlphRange("0-9A-Z $%*+-./:").join("");
         input = new Uint8Array(input);
         if (!input) return "";
 
@@ -54,7 +57,7 @@ class ToBase45 extends Operation {
 
             let chars = 0;
             do {
-                res.push(alphabet[b % 45]);
+                res.push(ALPHABET[b % 45]);
                 chars++;
                 b = Math.floor(b / 45);
             } while (b > 0);

--- a/tests/operations/index.mjs
+++ b/tests/operations/index.mjs
@@ -20,6 +20,7 @@ import TestRegister from "../lib/TestRegister.mjs";
 import "./tests/BCD.mjs";
 import "./tests/BSON.mjs";
 import "./tests/BaconCipher.mjs";
+import "./tests/Base45.mjs";
 import "./tests/Base58.mjs";
 import "./tests/Base64.mjs";
 import "./tests/Base62.mjs";

--- a/tests/operations/tests/Base45.mjs
+++ b/tests/operations/tests/Base45.mjs
@@ -1,0 +1,101 @@
+/**
+ * Base45 tests.
+ *
+ * @author Thomas Weißschuh [thomas@t-8ch.de]
+ *
+ * @copyright Crown Copyright 2021
+ * @license Apache-2.0
+ */
+
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        name: "To Base45: nothing",
+        input: "",
+        expectedOutput: "",
+        recipeConfig: [
+            {
+                op: "To Base45",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "To Base45: Spec encoding example 1",
+        input: "AB",
+        expectedOutput: "BB8",
+        recipeConfig: [
+            {
+                op: "To Base45",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "To Base45: Spec encoding example 2",
+        input: "Hello!!",
+        expectedOutput: "%69 VD92EX0",
+        recipeConfig: [
+            {
+                op: "To Base45",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "To Base45: Spec encoding example 3",
+        input: "base-45",
+        expectedOutput: "UJCLQE7W581",
+        recipeConfig: [
+            {
+                op: "To Base45",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "From Base45: nothing",
+        input: "",
+        expectedOutput: "",
+        recipeConfig: [
+            {
+                op: "From Base45",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "From Base45: Spec decoding example 1",
+        input: "QED8WEX0",
+        expectedOutput: "ietf!",
+        recipeConfig: [
+            {
+                op: "From Base45",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "From Base45: Invalid character",
+        input: "!",
+        expectedOutput: "Character not in alphabet: '!'",
+        recipeConfig: [
+            {
+                op: "From Base45",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "From Base45: Invalid triplet value",
+        input: "ZZZ",
+        expectedOutput: "Triplet too large: 'ZZZ'",
+        recipeConfig: [
+            {
+                op: "From Base45",
+                args: [],
+            },
+        ],
+    },
+]);


### PR DESCRIPTION
Hi Thomas,

First thank you for initiating the support of base45 into CyberChef. I think, the way you are transforming the triplet into the MSB and LSB byte is incorrect. If MSB or LSB is 0x00 it shouldn't be ignored. Here is in this PR a proposal to fix this. Let me know if you disagree ;)

Have a nice day !

Cyril